### PR TITLE
Step 2a: Avoid copying byte array for `ResponseBytes`

### DIFF
--- a/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/core/internal/async/ByteArrayAsyncResponseTransformerAlternative.java
+++ b/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/core/internal/async/ByteArrayAsyncResponseTransformerAlternative.java
@@ -55,7 +55,7 @@ public final class ByteArrayAsyncResponseTransformerAlternative<ResponseT> imple
     @Override
     public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
         cf = new CompletableFuture<>();
-        return cf.thenApply(arr -> ResponseBytes.fromByteArray(response, arr));
+        return cf.thenApply(arr -> ResponseBytes.fromByteArrayUnsafe(response, arr));
     }
 
     @Override


### PR DESCRIPTION
This is a copy of https://github.com/rtyley/aws-sdk-async-response-bytes/pull/4, just to evaluate how effective Changes 1 & 3 are together, without Change 2.