### PR TITLE
Change A1: Tell ByteArrayOutputStream required capacity

### DIFF
--- a/src/main/java/com/madgag/aws/sdk/async/responsebytes/Main.java
+++ b/src/main/java/com/madgag/aws/sdk/async/responsebytes/Main.java
@@ -2,7 +2,7 @@ package com.madgag.aws.sdk.async.responsebytes;
 
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
-import com.madgag.aws.sdk.async.responsebytes.awssdk.core.async.AsyncResponseTransformerAlternative;
+import com.madgag.aws.sdk.async.responsebytes.awssdk.services.s3.AsyncS3ResponseTransformer;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
@@ -23,7 +23,7 @@ public class Main {
             KnownS3Object knownS3Object = KnownS3Object.BIG;
             ResponseBytes<GetObjectResponse> responseBytes = s3Client.getObject(
                     GetObjectRequest.builder().bucket(knownS3Object.bucket()).key(knownS3Object.key()).build(),
-                    AsyncResponseTransformerAlternative.toBytes()
+                    AsyncS3ResponseTransformer.toBytes()
             ).get();
             System.out.println(responseBytes.response().contentLength());
             HashCode hashOfDownloadedData = Hashing.sha256().hashBytes(responseBytes.asByteBuffer());

--- a/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/core/async/AsyncResponseTransformerAlternative.java
+++ b/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/core/async/AsyncResponseTransformerAlternative.java
@@ -4,8 +4,15 @@ import com.madgag.aws.sdk.async.responsebytes.awssdk.core.internal.async.ByteArr
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 
+import java.util.Optional;
+import java.util.function.Function;
+
 public class AsyncResponseTransformerAlternative {
     public static <ResponseT> AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> toBytes() {
-        return new ByteArrayAsyncResponseTransformerAlternative<>();
+        return new ByteArrayAsyncResponseTransformerAlternative<>(Optional.empty());
+    }
+
+    public static <ResponseT> AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> toBytes(Function<ResponseT, Integer> f) {
+        return new ByteArrayAsyncResponseTransformerAlternative<>(Optional.of(f));
     }
 }

--- a/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/services/s3/AsyncS3ResponseTransformer.java
+++ b/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/services/s3/AsyncS3ResponseTransformer.java
@@ -1,0 +1,13 @@
+package com.madgag.aws.sdk.async.responsebytes.awssdk.services.s3;
+
+import com.madgag.aws.sdk.async.responsebytes.awssdk.core.async.AsyncResponseTransformerAlternative;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+public class AsyncS3ResponseTransformer {
+
+    public static AsyncResponseTransformer<GetObjectResponse, ResponseBytes<GetObjectResponse>> toBytes() {
+        return AsyncResponseTransformerAlternative.toBytes(r -> r.contentLength().intValue());
+    }
+}


### PR DESCRIPTION
The byte array in `ByteArrayOutputStream` doubles in size every time capacity is exhausted - for an object just over 1GB in size, the buffer will eventually grow to 2GB in size - unnecessarily large, and involving a lot of array copies (`ceil(log_2 (N/32))` copies).

https://github.com/openjdk/jdk/blob/218829e0a2a3ae5599b81733df53557966392033/src/java.base/share/classes/java/io/ByteArrayOutputStream.java#L100-L101

If we just tell the Content Length to initialise the `ByteArrayOutputStream` with a byte array of the right size, the array will never get bigger than it needs to be - and it won't have do array-resizing either.

**Required RAM: [934 MB](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058092753?pr=8#summary-16439895976)**