### PR TITLE
Change A2: Use fixed-length byte array rather than ByteArrayOutputStream

### DIFF
--- a/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/utils/BinaryUtilsAlternative.java
+++ b/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/utils/BinaryUtilsAlternative.java
@@ -1,0 +1,23 @@
+package com.madgag.aws.sdk.async.responsebytes.awssdk.utils;
+
+import java.nio.ByteBuffer;
+
+public class BinaryUtilsAlternative {
+    /**
+     * This behaves identically to {@link software.amazon.awssdk.utils.BinaryUtils#copyBytesFrom(ByteBuffer)}, except
+     * that the bytes are copied to the supplied destination array, at the supplied destination offset.
+     */
+    public static int copyBytes(ByteBuffer bb, byte[] dest, int destOffset) {
+        if (bb == null) {
+            return 0;
+        }
+
+        int remaining = bb.remaining();
+        if (bb.hasArray()) {
+            System.arraycopy(bb.array(), bb.arrayOffset() + bb.position(), dest, destOffset, remaining);
+        } else {
+            bb.asReadOnlyBuffer().get(dest, destOffset, remaining);
+        }
+        return remaining;
+    }
+}


### PR DESCRIPTION
Reading out of a `ByteArrayOutputStream`
----------------------------------------

There's no properly supported way to get the ultimate cumulative byte array stored in a `ByteArrayOutputStream` without doing an array copy - that's what `ByteArrayOutputStream.toByteArray()` does, and that means:

* While copying, the JVM heap must briefly hold both the old & new byte arrays - roughly speaking, doubling the memory requirements.
* Copying the bytes from one array to another takes a little bit of CPU time (obviously this varies: `System.arraycopy()` for 40MB of bytes takes ~2ms on my M1 machine).

Writing into a `ByteArrayOutputStream`
--------------------------------------

The new `KnownLengthStore` implementation does 1 array copy for a write.

The `BaosStore` implementation:

* Allocates a new array 'X' with the size of the new incoming data chunk
* Copies data into that array 'X'
* Copies array 'X' into the instance's cumulative byte array

**Required RAM: [644 MB](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058095645?pr=10#summary-16439901557)**