### PR TITLE
Change B: Avoid copying byte array for `ResponseBytes`

### DIFF
--- a/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/core/internal/async/ByteArrayAsyncResponseTransformerAlternative.java
+++ b/src/main/java/com/madgag/aws/sdk/async/responsebytes/awssdk/core/internal/async/ByteArrayAsyncResponseTransformerAlternative.java
@@ -56,7 +56,7 @@ public final class ByteArrayAsyncResponseTransformerAlternative<ResponseT> imple
     @Override
     public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
         cf = new CompletableFuture<>();
-        return cf.thenApply(arr -> ResponseBytes.fromByteArray(response, arr));
+        return cf.thenApply(arr -> ResponseBytes.fromByteArrayUnsafe(response, arr));
     }
 
     @Override


### PR DESCRIPTION
Once the `ByteArrayAsyncResponseTransformer` has gathered all the response bytes, we still need to wrap those bytes and the response object in a `ResponseBytes` instance - but if we use `ResponseBytes.fromByteArray()`, a whole new byte array will be allocated, which is bad for two reasons:

* While copying, the JVM heap must briefly hold both the old & new byte arrays - roughly speaking, doubling the memory requirements.
* Copying the bytes from one array to another takes a little bit of CPU time (obviously this varies: `System.arraycopy()` for 40MB of bytes takes ~2ms on my M1 machine).

A faster, more memory efficient alternative to `ResponseBytes.fromByteArray()` is `ResponseBytes.fromByteArrayUnsafe()`, added to the AWS SDK in August 2020 with https://github.com/aws/aws-sdk-java-v2/pull/1977 in response to https://github.com/aws/aws-sdk-java-v2/issues/1959. The 'Unsafe' in the name is a warning to users of this method that the underlying byte array is _not_ copied, and so could be susceptible to badly-behaving code manipulating the contents of the byte array after the `ResponseBytes` is handed to the calling code.

If only the trusted SDK code has access to the original byte array before `ResponseBytes` is handed over to the caller, and once the `ResponseBytes` instance is handed over to the caller, the SDK code has no further use for the original byte array, then it is safe to use `ResponseBytes.fromByteArrayUnsafe()` in the trusted SDK code, and return the resulting `ResponseBytes` to the user, saving a double-allocation of memory, and the CPU time for the copying of bytes.

See also:

* https://github.com/aws/aws-sdk-java-v2/issues/1959
* https://github.com/aws/aws-sdk-java-v2/pull/1977

**Required RAM: [357 MB](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058098624#summary-16439907698)**